### PR TITLE
Support for any external TokenService (TVM for example)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,6 @@ export {
     CachingPolicy
 } from './table';
 export {getCredentialsFromEnv} from './parse-env-vars';
-export {TokenAuthService} from './credentials';
+export {TokenAuthService, MetadataAuthService} from './credentials';
 export {withRetries, RetryParameters} from './retries';
 export {YdbError, StatusCode} from './errors';


### PR DESCRIPTION
Modify MetadataAuthService to support any external TokenService as argument. TVM for example.