### PR TITLE
fix: Move @types/pino to prod dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -114,10 +114,9 @@
       "integrity": "sha512-XgDgo6W10SeGEAM0k7FosJpvLCynOTYns4Xk3J5HGrA+UI/bKZ30PGMzOP5Lh2zs4259I71FSYLAtjnx3qhObw=="
     },
     "@types/pino": {
-      "version": "6.0.1",
-      "resolved": "http://storage.mds.yandex.net/get-npm/2789043/@types/pino/-/pino-6.0.1.tgz",
-      "integrity": "sha512-GkOWuzB1vs6yhx8j9LxwE4LG6NANwpIjxg2q/Iev0cegOtoX8NGNI7PaJ3nTE75/vW5LANFXmuBOEWXbTGdxgQ==",
-      "dev": true,
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/@types/pino/-/pino-6.3.4.tgz",
+      "integrity": "sha512-03MpZ/HP6GlG0oo5dcb8NBpI21zNESswTbaA0VB4uuigXfVy+XLmzh39CY6VCAahPMxCPtuqSEdhwGeA3AOYXg==",
       "requires": {
         "@types/node": "*",
         "@types/pino-std-serializers": "*",
@@ -126,18 +125,16 @@
     },
     "@types/pino-std-serializers": {
       "version": "2.4.1",
-      "resolved": "http://storage.mds.yandex.net/get-npm/1893413/@types/pino-std-serializers/-/pino-std-serializers-2.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/@types/pino-std-serializers/-/pino-std-serializers-2.4.1.tgz",
       "integrity": "sha512-17XcksO47M24IVTVKPeAByWUd3Oez7EbIjXpSbzMPhXVzgjGtrOa49gKBwxH9hb8dKv58OelsWQ+A1G1l9S3wQ==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/sonic-boom": {
       "version": "0.7.0",
-      "resolved": "http://storage.mds.yandex.net/get-npm/1893478/@types/sonic-boom/-/sonic-boom-0.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/@types/sonic-boom/-/sonic-boom-0.7.0.tgz",
       "integrity": "sha512-AfqR0fZMoUXUNwusgXKxcE9DPlHNDHQp6nKYUd4PSRpLobF5CCevSpyTEBcVZreqaWKCnGBr9KI1fHMTttoB7A==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "license": "Apache",
   "dependencies": {
     "@grpc/proto-loader": "^0.5.1",
+    "@types/pino": "^6.0.0",
     "grpc": "^1.24.3",
     "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.15",
@@ -47,7 +48,6 @@
     "@types/lodash": "^4.14.144",
     "@types/luxon": "^1.21.0",
     "@types/node": "10.17.20",
-    "@types/pino": "^6.0.0",
     "pino-pretty": "^3.6.1",
     "typescript": "^3.9.3"
   }


### PR DESCRIPTION
`@types/pino` is visible through public API in logging.d.ts, and `getLogger` expose actual `pino` from this package dependencies.

That means that one would have to install `@types/pino` along with `ydb-sdk` to actually use in with TS, and that types version should match version in `ydb-sdk`, even if pino is never actually used outside of `ydb-sdk`.