### PR TITLE
Refactor to promise helpers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -376,6 +376,11 @@
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
     },
+    "delay": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/delay/-/delay-4.4.0.tgz",
+      "integrity": "sha512-txgOrJu3OdtOfTiEOT2e76dJVfG/1dz2NZ4F0Pyt4UGZJryssMRp5vdM5wQoLwSOBNdrJv3F9PAhp/heqd7vrA=="
+    },
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -870,6 +870,11 @@
         "os-tmpdir": "^1.0.0"
       }
     },
+    "p-defer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
+      "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -875,6 +875,19 @@
       "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
       "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
     },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+    },
+    "p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "requires": {
+        "p-finally": "^1.0.0"
+      }
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "license": "Apache",
   "dependencies": {
     "@grpc/proto-loader": "^0.5.1",
+    "delay": "^4.4.0",
     "grpc": "^1.24.3",
     "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.15",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "lodash": "^4.17.15",
     "long": "^4.0.0",
     "luxon": "^1.21.2",
+    "p-defer": "^3.0.0",
     "pino": "^6.3.0",
     "protobufjs": "^6.8.8",
     "reflect-metadata": "^0.1.13",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "long": "^4.0.0",
     "luxon": "^1.21.2",
     "p-defer": "^3.0.0",
+    "p-timeout": "^3.2.0",
     "pino": "^6.3.0",
     "protobufjs": "^6.8.8",
     "reflect-metadata": "^0.1.13",

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -1,3 +1,4 @@
+import delay from 'delay';
 import grpc from 'grpc';
 import jwt from 'jsonwebtoken';
 import {DateTime} from 'luxon';
@@ -13,10 +14,6 @@ function makeCredentialsMetadata(token: string, dbName: string): grpc.Metadata {
     metadata.add('x-ydb-auth-ticket', token);
     metadata.add('x-ydb-database', dbName);
     return metadata;
-}
-
-async function sleep(milliseconds: number) {
-    await new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
 
 export interface IIAmCredentials {
@@ -139,7 +136,7 @@ export class MetadataAuthService implements IAuthService {
         }
         let tries = 0;
         while (!token && tries < MetadataAuthService.MAX_TRIES) {
-            await sleep(MetadataAuthService.TRIES_INTERVAL);
+            await delay(MetadataAuthService.TRIES_INTERVAL);
             tries++;
             token = this.tokenService.getToken();
         }

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -2,6 +2,7 @@ import delay from 'delay';
 import grpc from 'grpc';
 import jwt from 'jsonwebtoken';
 import {DateTime} from 'luxon';
+import pTimeout from 'p-timeout';
 import {GrpcService, ISslCredentials} from "./utils";
 import {TokenService} from 'yandex-cloud';
 import {yandex} from "../proto/bundle";
@@ -94,11 +95,8 @@ export class IamAuthService extends GrpcService<IamTokenService> implements IAut
     }
 
     private sendTokenRequest(): Promise<ICreateIamTokenResponse> {
-        const timedReject = new Promise((_, reject) => {
-            setTimeout(reject, this.tokenRequestTimeout);
-        });
         const tokenPromise = this.api.create({jwt: this.getJwtRequest()});
-        return Promise.race([timedReject, tokenPromise]) as Promise<ICreateIamTokenResponse>;
+        return pTimeout(tokenPromise, this.tokenRequestTimeout);
     }
 
     private async updateToken() {

--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import EventEmitter from 'events';
 import {DateTime} from 'luxon';
+import pTimeout from 'p-timeout';
 import {Ydb} from "../proto/bundle";
 import {AuthenticatedService, getOperationPayload} from "./utils";
 import {IAuthService} from "./credentials";
@@ -158,10 +159,7 @@ export default class DiscoveryService extends AuthenticatedService<DiscoveryServ
     }
 
     public ready(timeout: number): Promise<void> {
-        const timedRejection: Promise<void> = new Promise((_resolve, reject) => {
-            setTimeout(() => reject(new Error(`Failed to resolve in ${timeout}ms!`)), timeout);
-        });
-        return Promise.race([this.endpointsPromise, timedRejection]);
+        return pTimeout(this.endpointsPromise, timeout, new Error(`Failed to resolve in ${timeout}ms!`));
     }
 
     private async getEndpointRR(): Promise<Endpoint> {

--- a/src/retries.ts
+++ b/src/retries.ts
@@ -1,3 +1,4 @@
+import delay from 'delay';
 import {YdbError} from "./errors";
 import getLogger, {Logger} from './logging';
 import * as errors from './errors';
@@ -49,9 +50,7 @@ class RetryStrategy {
         const slotsCount = 1 << Math.min(retries, retryParameters.backoffCeiling);
         const maxDuration = slotsCount * retryParameters.backoffSlotDuration;
         const duration = Math.random() * maxDuration;
-        return new Promise((resolve) => {
-            setTimeout(resolve, duration);
-        });
+        await delay(duration);
     }
 
     async retry<T>(asyncMethod: () => Promise<T>) {


### PR DESCRIPTION
This fixes a bug in `DiscoveryService.prototype.ready`, `setTimeout` is not unrefed, and not canceled on succesful finishing.
So code like `const driver = new Driver(/* ... */); await driver.ready(30000); driver.destroy();`  will not exit for 30 seconds, waiting for timeout to expire.

Also this makes some places little bit simpler, IMO