### PR TITLE
Export missing types from credentials

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,11 @@ export {
     CachingPolicy
 } from './table';
 export {getCredentialsFromEnv} from './parse-env-vars';
-export {TokenAuthService, MetadataAuthService} from './credentials';
+export {
+    IAuthService,
+    ITokenService,
+    TokenAuthService,
+    MetadataAuthService,
+} from './credentials';
 export {withRetries, RetryParameters} from './retries';
 export {YdbError, StatusCode} from './errors';


### PR DESCRIPTION
These types are accessible via public API: `IAuthService` as a parameter for `Driver` constructor, `ITokenService` as a parameter for `MetadataAuthService` constructor.

Without direct exports user have to either import that type from specific file inside package (making file layout of a package part of public API), or, since it's only interfaces, replicate types in user code.