### PR TITLE
fix(DiscoveryService): correctly tell driver that endpoint is removed

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,6 @@
 export const ENDPOINT_DISCOVERY_PERIOD = 2 * 60 * 1000; // 2 minutes
 export const SESSION_KEEPALIVE_PERIOD = 60 * 1000; // 1 minute
+
+export enum Events {
+    ENDPOINT_REMOVED = 'endpoint:removed'
+}

--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -8,6 +8,7 @@ import {retryable} from "./retries";
 import getLogger, {Logger} from './logging';
 import DiscoveryServiceAPI = Ydb.Discovery.V1.DiscoveryService;
 import IEndpointInfo = Ydb.Discovery.IEndpointInfo;
+import {Events} from "./constants";
 
 
 type SuccessDiscoveryHandler = (result: Endpoint[]) => void;
@@ -125,7 +126,7 @@ export default class DiscoveryService extends AuthenticatedService<DiscoveryServ
         const endpointsToRemove = _.differenceBy(this.endpoints, endpoints);
         const endpointsToUpdate = _.intersectionBy(this.endpoints, endpoints, getHost);
 
-        _.forEach(endpointsToRemove, (endpoint) => this.emit('remove', endpoint));
+        _.forEach(endpointsToRemove, (endpoint) => this.emit(Events.ENDPOINT_REMOVED, endpoint));
 
         for (const current of endpointsToUpdate) {
             const newEndpoint =

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -6,6 +6,7 @@ import {IAuthService} from "./credentials";
 import {TimeoutExpired} from "./errors";
 import getLogger, {Logger} from "./logging";
 import SchemeClient from "./scheme";
+import {Events} from './constants'
 
 
 export interface DriverSettings {
@@ -29,7 +30,7 @@ export default class Driver {
         this.discoveryService = new DiscoveryService(
             this.entryPoint, this.database, ENDPOINT_DISCOVERY_PERIOD, authService
         );
-        this.discoveryService.on('removed', (endpoint: Endpoint) => {
+        this.discoveryService.on(Events.ENDPOINT_REMOVED, (endpoint: Endpoint) => {
             this.sessionCreators.delete(endpoint);
         });
         this.sessionCreators = new Map();


### PR DESCRIPTION
Use the same event name in DiscoveryService and in driver.