### PR TITLE
Specifies ydb-sdk protobuf.roots

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build:bundle": "pbjs -t static-module -w commonjs -p . `ls kikimr/public/api/grpc/*.proto` yandex/cloud/iam/v1/iam_token_service.proto > proto/bundle.js && pbts -o proto/bundle.d.ts proto/bundle.js",
+    "build:bundle": "pbjs -t static-module -r ydb-sdk -w commonjs -p . `ls kikimr/public/api/grpc/*.proto` yandex/cloud/iam/v1/iam_token_service.proto > proto/bundle.js && pbts -o proto/bundle.d.ts proto/bundle.js",
     "build:lib": "tsc",
     "build:examples": "cd examples && npm run build",
     "basic-example-v1": "cd examples && npm run basic-v1",

--- a/proto/bundle.js
+++ b/proto/bundle.js
@@ -7,7 +7,7 @@ var $protobuf = require("protobufjs/minimal");
 var $Reader = $protobuf.Reader, $Writer = $protobuf.Writer, $util = $protobuf.util;
 
 // Exported root namespace
-var $root = $protobuf.roots["default"] || ($protobuf.roots["default"] = {});
+var $root = $protobuf.roots["ydb-sdk"] || ($protobuf.roots["ydb-sdk"] = {});
 
 $root.Ydb = (function() {
 


### PR DESCRIPTION
By default pbjs compiles proto to root['default'] which may have conflicts with project bundles. For example, root.google.protobuf from ydb-sdk bundle hasn't method BoolValue.