### PR TITLE
Fix MetadataAuthService: refetch token right after init

### DIFF
--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -129,6 +129,7 @@ export class MetadataAuthService implements IAuthService {
         let token = this.tokenService.getToken();
         if (!token && typeof this.tokenService.initialize === 'function') {
             await this.tokenService.initialize();
+            token = this.tokenService.getToken();
         }
         let tries = 0;
         while (!token && tries < MetadataAuthService.MAX_TRIES) {


### PR DESCRIPTION
Before we had to wait `MetadataAuthService.TRIES_INTERVAL` (2 seconds) in the first iteration in the while loop, after successful TokenService initialization.

Now I re-fetch token right after init.

Timings before:
```
durationMs: 2095
durationMs: 2085
durationMs: 2090
```

After:
```
durationMs: 73
durationMs: 58
```

Test code
```js
const {Driver, getCredentialsFromEnv, getLogger} = require('ydb-sdk');
const logger = getLogger({level: 'debug'});
const entryPoint = 'grpcs://ydb.serverless.yandexcloud.net:2135';
const dbName = '...';
const authService = getCredentialsFromEnv(entryPoint, dbName, logger);
const driver = new Driver(entryPoint, dbName, authService);

let ctx;

async function run() {
  if (!await driver.ready(10000)) {
      logger.fatal(`Driver has not become ready in 10 seconds!`);
      process.exit(1);
  }
}

exports.handler = async event => {
    const ctxReused = ctx ? 'reused' : 'new';
    ctx = true;

    const start = Date.now();
    await run();
    const durationMs = Date.now() - start;

    return {
        'statusCode': 200,
        'headers': {
            'Content-Type': 'text/plain'
        },
        'isBase64Encoded': false,
        'body': `durationMs: ${durationMs}, ctx: ${ctxReused}`
    }
};
```