### PR TITLE
tune(driver): pass gRPC client options to driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 2.1.0
+* Allow passing gRPC [client options](https://grpc.github.io/grpc/core/group__grpc__arg__keys.html)
+  under `clientOptions` key to `Driver` constructor. This enables changing different
+  gRPC settings in `tableClient` and `schemaClient` calls.
+
 ### 2.0.0
 * BREAKING CHANGE: StorageSettings class exported at toplevel has changed its structure:
   the only public `storageKind` field has been renamed to `media`, type is the same. This

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -7,10 +7,12 @@ import {TimeoutExpired} from "./errors";
 import getLogger, {Logger} from "./logging";
 import SchemeClient from "./scheme";
 import {Events} from './constants'
+import {ClientOptions} from "./utils";
 
 
 export interface DriverSettings {
     poolSettings?: PoolSettings;
+    clientOptions?: ClientOptions;
 }
 
 export default class Driver {
@@ -68,7 +70,8 @@ export default class Driver {
     public async getSessionCreator(): Promise<SessionService> {
         const endpoint = await this.getEndpoint();
         if (!this.sessionCreators.has(endpoint)) {
-            this.sessionCreators.set(endpoint, new SessionService(endpoint, this.authService));
+            const sessionService = new SessionService(endpoint, this.authService, this.settings.clientOptions);
+            this.sessionCreators.set(endpoint, sessionService);
         }
         return this.sessionCreators.get(endpoint) as SessionService;
     }

--- a/src/table.ts
+++ b/src/table.ts
@@ -1,7 +1,13 @@
 import _ from 'lodash';
 import EventEmitter from 'events';
 import {Ydb} from '../proto/bundle';
-import {AuthenticatedService, ensureOperationSucceeded, getOperationPayload, pessimizable} from './utils';
+import {
+    AuthenticatedService,
+    ClientOptions,
+    ensureOperationSucceeded,
+    getOperationPayload,
+    pessimizable
+} from './utils';
 import {Endpoint} from './discovery';
 import Driver from './driver';
 import {SESSION_KEEPALIVE_PERIOD} from './constants';
@@ -33,9 +39,9 @@ export class SessionService extends AuthenticatedService<TableService> {
     public endpoint: Endpoint;
     private readonly logger: Logger;
 
-    constructor(endpoint: Endpoint, authService: IAuthService) {
+    constructor(endpoint: Endpoint, authService: IAuthService, clientOptions?: ClientOptions) {
         const host = endpoint.toString();
-        super(host, 'Ydb.Table.V1.TableService', TableService, authService);
+        super(host, 'Ydb.Table.V1.TableService', TableService, authService, clientOptions);
         this.endpoint = endpoint;
         this.logger = getLogger();
     }


### PR DESCRIPTION
Which in turn passes them to tableClient and schemaClient.